### PR TITLE
Fix broken idnaEncoded example in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -233,14 +233,14 @@ print(result.secondLevelDomain) // Optional("寿司")
 print(result.subDomain)         // Optional("www.ラーメン")
 ```
 
-Encode an unicode url by using [`Punycode`](https://github.com/futamura/PunycodeSwift) Framework:
+Encode a unicode hostname by using the [`Punycode`](https://github.com/futamura/PunycodeSwift) Framework. Note that `idnaEncoded` operates on hostnames — apply it to the host part only, not to a full URL including the scheme:
 
 ```swift
 import Punycode
 
-let urlString: String = "http://www.ラーメン.寿司.co.jp".idnaEncoded!
-let url: URL = URL(string: urlString)
-print(urlString)                // http://www.xn--4dkp5a8a.xn--sprr0q.co.jp
+let hostname: String = "www.ラーメン.寿司.co.jp".idnaEncoded!
+let url: URL = URL(string: "http://" + hostname)!
+print(hostname)                 // www.xn--4dkp5a8a.xn--sprr0q.co.jp
 
 guard let result: TLDResult = extractor.parse(url) else { return }
 


### PR DESCRIPTION
## Summary

- Fix the README example reported in #8: `idnaEncoded` is a hostname-level API, and applying it to a full URL mangles the scheme into the first label (`"http://www.ラーメン.寿司.co.jp".idnaEncoded` actually yields `xn--http://www-.xn--4dkp5a8a.xn--sprr0q.co.jp`, not the output the example claimed). The example now encodes the host part only and builds the URL from it.
- A URL-aware API (`idnaEncodedURL` / `idnaDecodedURL`) is planned for PunycodeSwift 4.0.0; this example will be updated to use it when the dependency is bumped.

Fixes #8.

## Test plan

- [ ] CI Success gate passes (docs-only change)
- [ ] Verified behavior against current PunycodeSwift: hostname-only input produces `www.xn--4dkp5a8a.xn--sprr0q.co.jp`, and the parse output comments match the existing punycoded-hostname example