### PR TITLE
Make the version lanes safe without a TTY

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - The bundled Public Suffix List is refreshed. `public_suffix_list_frozen.dat` and the `SPM_PSL` literal had not been regenerated since August 2024, so `useFrozenData: true` was resolving against a two-year-old list; `update-psl.py` now writes all three bundled copies from a single download.
 - `update-psl.py` requires Python 3 (the Python 2 branch is gone) and reports any rule it cannot punycode instead of failing silently.
 
+### Fixed
+
+- Maintainer tooling: the `set_version` / `bump_version` fastlane lanes accept `version:` / `type:` arguments and fail without a TTY instead of silently leaving the version untouched, and the version format check is anchored so that values such as `1a2b3` are rejected instead of written to the project.
+
 ## [4.0.1] - 2026-08-18
 
 ### Changed

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -29,7 +29,9 @@ bundle exec fastlane build_spm        # swift build + test
 bundle exec fastlane build_carthage   # Carthage builds per platform
 bundle exec fastlane gen_docs         # DocC static site into docc-site/ (via scripts/gen_docs.sh)
 bundle exec fastlane set_version      # prompt for version; sets MARKETING_VERSION in the pbxproj
+bundle exec fastlane set_version version:4.0.2   # non-interactive form
 bundle exec fastlane bump_version     # patch/minor/major bump; same effect
+bundle exec fastlane bump_version type:patch     # non-interactive form
 
 # Interactive job menu (fzf)
 ./run.sh
@@ -70,7 +72,7 @@ Tests live in `Tests/TLDExtractSwiftTests.swift` (single XCTest file; SPM test t
 
 ## Versioning and release
 
-- Single source of truth for the version: `MARKETING_VERSION` in `TLDExtractSwift.xcodeproj/project.pbxproj`. Never edit versions by hand — use `fastlane set_version` / `bump_version`.
+- Single source of truth for the version: `MARKETING_VERSION` in `TLDExtractSwift.xcodeproj/project.pbxproj`. Never edit versions by hand — use `fastlane set_version` / `bump_version`. Both lanes prompt only when stdin is a TTY; without one, pass `version:` / `type:` or the lane fails rather than silently leaving the version untouched.
 - Branch flow: work on `develop`, PR into `main`.
 - CI (`.github/workflows/main.yml`) runs on push and pull request to `main`/`develop`: swift-format lint → per-platform xcodebuild tests (simulator devices resolved at runtime via `simctl`) → SPM (macOS + Linux via the official Swift container). It does not release. Carthage builds are not CI-verified (best-effort compatibility via the Xcode project). The `CI Success` job aggregates all results and is the required status check on `main`.
 - Documentation (`.github/workflows/docs.yml`) builds the DocC site with `scripts/gen_docs.sh` (symbolgraph-extract with `-emit-extension-block-symbols` — required because part of the public API is extensions on URL/String — then `docc convert`) and deploys it to GitHub Pages on every push to `main`. The site is not tracked in git; `docs/` no longer exists.

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -17,26 +17,37 @@ end
 ##########################################
 
 desc "Set version number"
-lane :set_version do
+lane :set_version do |options|
     current_app_version = get_version_number_from_xcodeproj(xcodeproj: xcodeproj_file)
-    new_app_version = prompt(
-        text: "Please enter version number (Current: #{current_app_version}): ",
-        ci_input: current_app_version
-    )
-    regexp = Regexp.new("[0-9]+\.[0-9]+\.[0-9]+")
-    matched = regexp.match(new_app_version)
-    if matched then
-        # Set version number to project
-        increment_version_number_in_xcodeproj(version_number: new_app_version)
-        UI.message("Changed version from #{current_app_version} to #{new_app_version} ")
-    else
-        UI.error("Invalid version number. #{new_app_version}")
+    new_app_version = options[:version]&.to_s
+    if new_app_version.nil? then
+        unless UI.interactive? then
+            UI.user_error!("No TTY to prompt on. Pass the version instead: fastlane set_version version:#{current_app_version}")
+        end
+        new_app_version = UI.input("Please enter version number (Current: #{current_app_version}): ")
     end
+    # Anchored so that partial matches such as "1a2b3" are rejected
+    unless new_app_version.match?(/\A\d+\.\d+\.\d+\z/) then
+        UI.user_error!("Invalid version number. #{new_app_version}")
+    end
+    # Set version number to project
+    increment_version_number_in_xcodeproj(version_number: new_app_version)
+    UI.message("Changed version from #{current_app_version} to #{new_app_version} ")
 end
 
 desc "Bump version number"
-lane :bump_version do
-    bump_type = UI.select("Select version position to be upgraded: ", ["patch", "minor", "major"])
+lane :bump_version do |options|
+    bump_types = ["patch", "minor", "major"]
+    bump_type = options[:type]&.to_s
+    if bump_type.nil? then
+        unless UI.interactive? then
+            UI.user_error!("No TTY to prompt on. Pass the bump type instead: fastlane bump_version type:patch")
+        end
+        bump_type = UI.select("Select version position to be upgraded: ", bump_types)
+    end
+    unless bump_types.include?(bump_type) then
+        UI.user_error!("Invalid bump type. #{bump_type} (expected one of: #{bump_types.join(", ")})")
+    end
     current_app_version = get_version_number_from_xcodeproj(xcodeproj: xcodeproj_file)
     current_app_versions = current_app_version.split(".")
     current_app_version_patch = current_app_versions[2].to_i


### PR DESCRIPTION
Mirrors futamura/PunycodeSwift#86 — the two repositories carry identical `set_version` / `bump_version` lanes, and both had the same two defects.

## Fixes

- **Silent no-op without a TTY**: piped stdin sent `prompt` into its `ci_input` branch, which fed back the current version — the lane reported "Changed version from X to X" and wrote nothing.
- **Broken version validation**: the pattern was built from a double-quoted string, so `\.` collapsed to `.` (any character) and the match was unanchored. Values like `1a2b3` or `v4.0.2-beta` passed and were written to the pbxproj verbatim.

## Behavior now

- `fastlane set_version version:4.0.2` / `fastlane bump_version type:patch` work non-interactively.
- Without a TTY and without an argument, the lane exits 1 with guidance instead of pretending to succeed.
- Version format is checked against `/\A\d+\.\d+\.\d+\z/`; invalid values and bump types exit 1.
- Interactive use via `./run.sh` is unchanged.

`CLAUDE.md` documents the non-interactive forms; the changelog records the fix under Unreleased.

## Verification

Five non-TTY cases verified here (valid version actually rewrites the pbxproj, no-arg fails with guidance, `1a2b3` rejected, `type:patch` bumps, `type:pathc` rejected); TTY paths verified on the PunycodeSwift side against the identical code.