### PR TITLE
Resolve PunycodeSwift at 4.0.1

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -5,8 +5,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/futamura/PunycodeSwift.git",
       "state" : {
-        "revision" : "a32282d44a320b4468ee8993246cbd6c62508b91",
-        "version" : "4.0.0"
+        "revision" : "3444734023611722a0be708cec4496798dfebefb",
+        "version" : "4.0.1"
       }
     }
   ],


### PR DESCRIPTION
## Summary

- Update `Package.resolved` to pin PunycodeSwift 4.0.1 (revision `3444734`, the commit the 4.0.1 tag points at). The pin had stayed at 4.0.0 while `Cartfile.resolved` already moved to 4.0.1, so local development and CI were building against the older revision. Downstream SPM consumers are unaffected either way — they resolve their own graph.

`swift test` passed 6/6 with the updated pin (verified on develop before push).

## Test plan

- [ ] CI Success gate passes