### PR TITLE
chore: configure Swift Package Index listing

### DIFF
--- a/.spi.yml
+++ b/.spi.yml
@@ -1,0 +1,5 @@
+version: 1
+builder:
+  configs:
+    - documentation_targets: [TLDExtractSwift]
+      custom_documentation_parameters: [--include-extended-types]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - A weekly workflow that refreshes the bundled Public Suffix List, runs the test suite against the new data, and opens a pull request when it changed.
+- Swift Package Index listing, with an `.spi.yml` that has SPI build and host the DocC documentation alongside the GitHub Pages site. The README gains the SPI Swift version and platform compatibility badges.
 
 ### Changed
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 [![Swift Package Manager compatible](https://img.shields.io/badge/Swift_Package_Manager-compatible-orange)](https://github.com/futamura/TLDExtractSwift)
 ![Carthage](https://img.shields.io/badge/Carthage-Compatible-blue)
+[![Swift Package Index](https://img.shields.io/endpoint?url=https%3A%2F%2Fswiftpackageindex.com%2Fapi%2Fpackages%2Ffutamura%2FTLDExtractSwift%2Fbadge%3Ftype%3Dswift-versions)](https://swiftpackageindex.com/futamura/TLDExtractSwift)
+[![Platforms](https://img.shields.io/endpoint?url=https%3A%2F%2Fswiftpackageindex.com%2Fapi%2Fpackages%2Ffutamura%2FTLDExtractSwift%2Fbadge%3Ftype%3Dplatforms)](https://swiftpackageindex.com/futamura/TLDExtractSwift)
 [![Build](https://github.com/futamura/TLDExtractSwift/actions/workflows/main.yml/badge.svg)](https://github.com/futamura/TLDExtractSwift/actions/workflows/main.yml)
 [![codecov](https://codecov.io/gh/futamura/TLDExtractSwift/branch/main/graph/badge.svg)](https://codecov.io/gh/futamura/TLDExtractSwift)
 ![Language](https://img.shields.io/badge/Language-Swift%205.9-orange.svg)


### PR DESCRIPTION
## Summary

Prepares the repository for a Swift Package Index listing.

- **`.spi.yml`** — has SPI build and host the DocC documentation for the `TLDExtractSwift` target. `custom_documentation_parameters: [--include-extended-types]` is required here: part of the public API is extensions on `URL` and `String`, and those symbols are dropped without the flag (the same reason `scripts/gen_docs.sh` passes `-emit-extension-block-symbols`). SPI injects the Swift-DocC plugin itself, so `Package.swift` is unchanged.
- **README** — SPI Swift version and platform compatibility badges, grouped with the other distribution badges. They render as unknown until the package is accepted into the index and built for the first time.
- **CHANGELOG** — one entry under Unreleased / Added.

The existing GitHub Pages documentation site and `docs.yml` are untouched; SPI hosting is additive and gives per-version documentation, which Pages does not.

## Coordination

Matched with [futamura/PunycodeSwift#88](https://github.com/futamura/PunycodeSwift/pull/88), which lands the same `.spi.yml` shape and badge placement.

## Follow-up (not in this PR)

After this and the PunycodeSwift PR are merged to `main`, a single issue on `SwiftPackageIndex/PackageList` submits both `https://github.com/futamura/PunycodeSwift.git` and `https://github.com/futamura/TLDExtractSwift.git`. Note for that issue: the index already lists the fork `MarcoEidinger/TLDExtractSwift`, so the canonical repository is not a duplicate submission.

## Verification

- `.spi.yml` parses as YAML and its keys match `SPIManifest.Manifest` (`version`, `builder.configs[].documentation_targets`, `custom_documentation_parameters`).
- No source or manifest changes, so CI coverage is unchanged.