### PR TITLE
chore: set the author line on the Swift Package Index page

### DIFF
--- a/.spi.yml
+++ b/.spi.yml
@@ -1,4 +1,8 @@
 version: 1
+# Overrides the author line SPI derives from the commit history, which still
+# credits the repository's former `gumob` handle.
+metadata:
+  authors: Kojiro Futamura and contributors
 builder:
   configs:
     - documentation_targets: [TLDExtractSwift]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - A weekly workflow that refreshes the bundled Public Suffix List, runs the test suite against the new data, and opens a pull request when it changed.
-- Swift Package Index listing, with an `.spi.yml` that has SPI build and host the DocC documentation alongside the GitHub Pages site. The README gains the SPI Swift version and platform compatibility badges.
+- Swift Package Index listing, with an `.spi.yml` that has SPI build and host the DocC documentation alongside the GitHub Pages site and sets the author line shown on the package page. The README gains the SPI Swift version and platform compatibility badges.
 
 ### Changed
 


### PR DESCRIPTION
## Summary

The [package page](https://swiftpackageindex.com/futamura/TLDExtractSwift) currently opens with *"Written by gumob and 3 other contributors."* The Swift Package Index derives that line from the commit history, which still credits the repository's former `gumob` handle. `metadata.authors` in `.spi.yml` overrides it.

```yaml
metadata:
  authors: Kojiro Futamura and contributors
```

The value omits a contributor count so it does not go stale. The change takes effect when SPI next reprocesses the default branch.

## Coordination

Matched with [futamura/PunycodeSwift#89](https://github.com/futamura/PunycodeSwift/pull/89), which sets the identical line.

## Documentation build (verified)

The first SPI build of #64 is done, and `custom_documentation_parameters: [--include-extended-types]` worked — no fallback to `external_links.documentation` is needed:

- `documentation/tldextractswift` lists **Extended Modules → Foundation, Swift** alongside the regular topics.
- `foundation/url` renders as *Extended Structure URL*, conforming to `TLDExtractable`, with the doc comments intact.
- `swift/string` renders as *Extended Structure String*, including the `hostname` overview.

Compatibility builds are green for `4.0.1` and `main` across Swift 6.0–6.3 and iOS/macOS/visionOS/watchOS/tvOS/Linux/Wasm/Android, with zero data race safety errors.

## Verification

- `.spi.yml` parses as YAML and its keys match `SPIManifest.Manifest` (`metadata.authors` is a plain string there).
- No source or manifest changes, so CI coverage is unchanged.