### PR TITLE
fix: make the Swift Package Index author line a full sentence

### DIFF
--- a/.spi.yml
+++ b/.spi.yml
@@ -1,8 +1,10 @@
 version: 1
 # Overrides the author line SPI derives from the commit history, which still
-# credits the repository's former `gumob` handle.
+# credits the repository's former `gumob` handle. SPI renders this value
+# verbatim -- unlike the derived line, it gets no "Written by" prefix and no
+# full stop -- so the value has to be a complete sentence.
 metadata:
-  authors: Kojiro Futamura and contributors
+  authors: Written by Kojiro Futamura and contributors.
 builder:
   configs:
     - documentation_targets: [TLDExtractSwift]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project are documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+
+- The author line on the Swift Package Index page reads as a sentence again. SPI renders `metadata.authors` from `.spi.yml` verbatim, without the "Written by" prefix and full stop it adds to the line it derives from the commit history, so the value now carries them itself.
+
 ## [4.0.2] - 2026-08-21
 
 ### Added


### PR DESCRIPTION
## Summary

[#65](https://github.com/futamura/TLDExtractSwift/pull/65) set `metadata.authors` to `Kojiro Futamura and contributors`, on the assumption that SPI would render it the same way it renders the line it derives from the commit history. It does not. The value becomes the whole line, so it would have appeared as a bare fragment among the sentences around it. The value now carries the prefix and the full stop itself:

```yaml
metadata:
  authors: Written by Kojiro Futamura and contributors.
```

A comment above the key records why, so a future edit does not strip them again. The change has not reached the package page yet, so the first version anyone sees will be the correct one.

## Why this is the rendering

From `SwiftPackageIndex-Server` on `main`:

`Sources/App/Views/PackageController/GetRoute.Model+ext.swift`, `authorsListItem()` — the manifest value goes out as plain text, while the git-derived path wraps its nodes:

```swift
case .fromSPIManifest(var spiymlAuthors) :
    if spiymlAuthors.count > 200 { spiymlAuthors = String(spiymlAuthors.prefix(200)) + "&hellip;" }
    return .li(.class("authors"), .text(spiymlAuthors))

case .fromGitRepository(let repositoryAuthors) :
    ...
    .group(listPhrase(opening: "Written by ", nodes: nodes, closing: "."))
```

Packages in the index use the field as a free-form line, which matches: `vapor/vapor` carries a full sentence ending in a full stop, while `firebase/firebase-ios-sdk` and `swiftlang/swift-testing` carry bare names (`Google`, `Apple Inc.`) that read fine on their own. A phrase like ours needs the verb.

## No release needed

`Sources/App/Controllers/API/API+PackageController+PackageResult.swift`, `authors()`, reads `defaultBranchVersion.spiManifest` — the author line comes from the default branch only, never from a release:

```swift
if let spiManifest = defaultBranchVersion.spiManifest,
   let metadata = spiManifest.metadata,
   let authors = metadata.authors {
    return .fromSPIManifest(authors)
```

So merging to `main` is what puts this in front of SPI; tagging 4.0.3 would not make it land any sooner. That also corrects the expectation in [#66](https://github.com/futamura/TLDExtractSwift/pull/66): cutting 4.0.2 updated the *Latest Release* on the page, but it could never have advanced the author line. The changelog entry sits under Unreleased and will ship with whatever the next release turns out to be.

## Coordination

Matched with [futamura/PunycodeSwift#91](https://github.com/futamura/PunycodeSwift/pull/91), which lands the identical value and comment.

## Verification

- `.spi.yml` parses as YAML; `metadata.authors` is 44 characters, well under the 200 SPI truncates at, and the file is 496 bytes against SPIManifest's 1500 byte limit.
- No source or manifest changes, so CI coverage is unchanged.