### PR TITLE
chore: drop the hardcoded language badge from the README

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Removed
+
+- The hardcoded "Language: Swift 5.9" README badge. It duplicated the Swift Package Index Swift version badge, which reports the versions the package actually builds against instead of a number kept up to date by hand.
+
 ### Fixed
 
 - The author line on the Swift Package Index page reads as a sentence again. SPI renders `metadata.authors` from `.spi.yml` verbatim, without the "Written by" prefix and full stop it adds to the line it derives from the commit history, so the value now carries them itself.

--- a/README.md
+++ b/README.md
@@ -4,7 +4,6 @@
 [![Platforms](https://img.shields.io/endpoint?url=https%3A%2F%2Fswiftpackageindex.com%2Fapi%2Fpackages%2Ffutamura%2FTLDExtractSwift%2Fbadge%3Ftype%3Dplatforms)](https://swiftpackageindex.com/futamura/TLDExtractSwift)
 [![Build](https://github.com/futamura/TLDExtractSwift/actions/workflows/main.yml/badge.svg)](https://github.com/futamura/TLDExtractSwift/actions/workflows/main.yml)
 [![codecov](https://codecov.io/gh/futamura/TLDExtractSwift/branch/main/graph/badge.svg)](https://codecov.io/gh/futamura/TLDExtractSwift)
-![Language](https://img.shields.io/badge/Language-Swift%205.9-orange.svg)
 ![License](https://img.shields.io/github/license/futamura/TLDExtractSwift.svg)
 
 # TLDExtract


### PR DESCRIPTION
## Summary

Removes one README badge:

```markdown
![Language](https://img.shields.io/badge/Language-Swift%205.9-orange.svg)
```

It claimed Swift 5.9 — the `swift-tools-version` from `Package.swift`, not a statement about what the package compiles with — and it now sits next to the Swift Package Index Swift version badge added in 4.0.2, which reports the versions the package actually builds against: 6.3, 6.2, 6.1, 6.0. Two badges for the same question, and the one that has to be updated by hand is already wrong.

Remaining badges, in order: SPM, Carthage, SPI Swift versions, SPI platforms, Build, codecov, License.

## Coordination

Matched with [futamura/PunycodeSwift#92](https://github.com/futamura/PunycodeSwift/pull/92), which removes the identical line.

## Changelog

A `### Removed` section under Unreleased, placed before the existing `### Fixed` to keep the Keep a Changelog section order.

## Verification

- The removed line was the only `Language` badge in the README; the surrounding badge lines are untouched.
- No source or manifest changes, so CI coverage is unchanged.