### PR TITLE
chore: refresh the bundled Public Suffix List

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project are documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Changed
+
+- The bundled Public Suffix List is refreshed. `aivencloud.com` is no longer a rule of its own, so the bare host now parses as a registrable domain under `com`; the `*.aivencloud.com` wildcard is unchanged. `claudeusercontent.com` and `frame.claudeusercontent.com` are added.
+
 ## [4.0.3] - 2026-08-22
 
 ### Added

--- a/Resources/public_suffix_list.dat
+++ b/Resources/public_suffix_list.dat
@@ -7427,7 +7427,6 @@ africa.com
 *.auiusercontent.com
 beep.pl
 aiven.app
-aivencloud.com
 *.aivencloud.com
 akadns.net
 akamai.net
@@ -8303,6 +8302,8 @@ eero-stage.online
 opentunnel.xyz
 antagonist.cloud
 claude.app
+claudeusercontent.com
+frame.claudeusercontent.com
 *.cursorusercontent.com
 apigee.io
 panel.dev

--- a/Resources/public_suffix_list_frozen.dat
+++ b/Resources/public_suffix_list_frozen.dat
@@ -7427,7 +7427,6 @@ africa.com
 *.auiusercontent.com
 beep.pl
 aiven.app
-aivencloud.com
 *.aivencloud.com
 akadns.net
 akamai.net
@@ -8303,6 +8302,8 @@ eero-stage.online
 opentunnel.xyz
 antagonist.cloud
 claude.app
+claudeusercontent.com
+frame.claudeusercontent.com
 *.cursorusercontent.com
 apigee.io
 panel.dev

--- a/Sources/SPMPSL.swift
+++ b/Sources/SPMPSL.swift
@@ -7438,7 +7438,6 @@ africa.com
 *.auiusercontent.com
 beep.pl
 aiven.app
-aivencloud.com
 *.aivencloud.com
 akadns.net
 akamai.net
@@ -8314,6 +8313,8 @@ eero-stage.online
 opentunnel.xyz
 antagonist.cloud
 claude.app
+claudeusercontent.com
+frame.claudeusercontent.com
 *.cursorusercontent.com
 apigee.io
 panel.dev


### PR DESCRIPTION
Brings the weekly Public Suffix List refresh (#71) into `main`.

The upstream list changed in two places:

- `aivencloud.com` is gone as a rule of its own; `*.aivencloud.com` stays, so only the bare `aivencloud.com` host changes how it parses.
- `claudeusercontent.com` and `frame.claudeusercontent.com` are added.

`update-psl.py` rewrote all three bundled copies (`Resources/public_suffix_list.dat`, `Resources/public_suffix_list_frozen.dat`, and the `SPM_PSL` literal) from a single download, so they stay identical.

The parser tests ran against this list in the workflow that opened #71 (run 33376002360, `swift:6.2`) before the pull request was created.