### PR TITLE
fix: stop the CI flakes that block the weekly PSL update

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -148,7 +148,23 @@ jobs:
             exit 1
           fi
           echo "Testing on simulator: $device"
-          env NSUnbufferedIO=YES xcodebuild -project "${{ env.project_name }}.xcodeproj" -scheme ${{ env.scheme }} -destination "platform=${{ matrix.platform }} Simulator,name=$device" clean test 2>&1 | xcbeautify --renderer github-actions
+          run_tests() {
+            env NSUnbufferedIO=YES xcodebuild -project "${{ env.project_name }}.xcodeproj" -scheme ${{ env.scheme }} -destination "platform=${{ matrix.platform }} Simulator,name=$device" clean test 2>&1 | xcbeautify --renderer github-actions
+          }
+          ### The simulator sometimes runs every test and then aborts during teardown
+          ### with SIGABRT (exit 134), which is a simulator fault rather than a failing
+          ### test. Retry once on 134 alone; any other non-zero status is a real failure
+          ### and fails the job straight away.
+          set +e
+          run_tests
+          status=$?
+          set -e
+          if [ "$status" -eq 134 ]; then
+            echo "::warning::xcodebuild aborted with 134 after the tests had finished; retrying once."
+            run_tests
+          elif [ "$status" -ne 0 ]; then
+            exit "$status"
+          fi
     needs: lint_code
 
   SPM:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - The bundled Public Suffix List is refreshed. `aivencloud.com` is no longer a rule of its own, so the bare host now parses as a registrable domain under `com`; the `*.aivencloud.com` wildcard is unchanged. `claudeusercontent.com` and `frame.claudeusercontent.com` are added.
 
+### Fixed
+
+- Maintainer tooling: the performance measurements no longer fail the Linux test job. Apple's XCTest treats a relative standard deviation over its 10% limit as information when no baseline is recorded, but swift-corelibs-xctest fails the test and offers no API to relax the limit, so a single slow iteration on a shared runner turned the build red. On Linux the blocks now run once untimed, which keeps the assertions inside them - the only coverage the extraction paths have - while giving up only the timing. This had already cost a week of Public Suffix List updates, since the weekly refresh workflow gates its pull request on `swift test` in a Linux container.
+- Maintainer tooling: the simulator test jobs retry once when `xcodebuild` aborts with exit code 134, which the simulator does during teardown after every test has already run. Any other non-zero status still fails the job immediately.
+
 ## [4.0.3] - 2026-08-22
 
 ### Added

--- a/Tests/TLDExtractSwiftTests.swift
+++ b/Tests/TLDExtractSwiftTests.swift
@@ -18,9 +18,30 @@ class TLDExtractSwiftTests: XCTestCase {
         tldExtractor = try? TLDExtract(useFrozenData: false)
     }
 
+    /// Runs `block` under `measure` everywhere except Linux, where it runs once untimed.
+    ///
+    /// Apple's XCTest reports a relative standard deviation over its 10% limit as
+    /// information when no baseline is recorded, and none is here; swift-corelibs-xctest
+    /// fails the test instead, and exposes no API to relax the limit. A single slow
+    /// iteration on a shared runner is enough to trip it, and that already cost a week of
+    /// Public Suffix List updates, because the weekly refresh workflow gates its pull
+    /// request on `swift test` in a Linux container. The assertions inside these blocks
+    /// are the only coverage the extraction paths get, so Linux keeps running them and
+    /// gives up only the timing.
+    private func measureIfSupported(_ block: () -> Void) {
+        #if os(Linux)
+        block()
+        #else
+        self.measure(block)
+        #endif
+    }
+
+    /// Measures parsing rather than the network: on the SPM path `TLDExtract()` defaults
+    /// to `useFrozenData: false` and downloads the list, so the ten iterations `measure`
+    /// runs would time ten HTTP downloads.
     func testMeasureSetupTime() {
-        self.measure {
-            _ = try? TLDExtract()
+        measureIfSupported {
+            _ = try? TLDExtract(useFrozenData: true)
         }
     }
 
@@ -59,20 +80,20 @@ class TLDExtractSwiftTests: XCTestCase {
     }
 
     func testMeasureExtractable() {
-        self.measure {
+        measureIfSupported {
             testExtractableURL()
             testExtractableString()
         }
     }
 
     func testMeasureParser() {
-        self.measure {
+        measureIfSupported {
             testTLDExtractString(quick: false)
         }
     }
 
     func testMeasureParserQuick() {
-        self.measure {
+        measureIfSupported {
             testTLDExtractString(quick: true)
         }
     }


### PR DESCRIPTION
Two CI flakes, one of which had real cost: the run on 2026-08-24 failed and held the Public Suffix List refresh back for a week.

## Performance measurements failing the Linux job

Apple's XCTest reports a relative standard deviation over its 10% limit as information when no baseline is recorded, and none is here. swift-corelibs-xctest fails the test instead, and exposes no API to relax the limit — `measureMetrics(_:automaticallyStartMeasuring:file:line:for:)` is all it offers, and `maxRelativeStandardDeviation` is internal. One slow iteration on a shared runner is enough:

```
testMeasureSetupTime average: 0.148, relative standard deviation: 71.421%
values: [0.105830, 0.104891, 0.122593, 0.104158, 0.104255, 0.447912, 0.137465, 0.120761, 0.123640, 0.110912]
error: failed: The relative standard deviation of the measurements is 71.421% which is higher than the max allowed of 10.000%.
```

Nine iterations sit between 0.104 and 0.137; one outlier at 0.448 does the damage.

On Linux the measured blocks now run once untimed, via a `measureIfSupported` helper. Skipping the tests outright would have been worse: the helpers they call take `file`/`line` arguments, so XCTest never discovers them as tests of their own, and the assertions inside these blocks are the only coverage the extraction paths get. Gating the tests off Linux dropped the job from six tests to two — the parser and the rule priorities, and nothing that parses a host.

`testMeasureSetupTime` also measured a download: on the SPM path `TLDExtract()` defaults to `useFrozenData: false`, so the ten iterations were timing ten HTTP requests. It now measures the frozen data.

## Simulator jobs aborting with exit 134

The simulator runs every test and then raises SIGABRT during teardown. The step now retries once on 134 alone; any other non-zero status still fails the job immediately, so a genuine failure is never retried into a pass.

## Verification

In the same `swift:6.2` container the refresh workflow uses, five consecutive runs pass with all six tests executing. Before the fix, the failure reproduced on the first run. On macOS the measurements still run and report as before.

## Not covered here

`PSL_UPDATE_TOKEN` is still unset, so the pull requests the refresh workflow opens continue to carry no checks of their own. The workflow already falls back to `GITHUB_TOKEN` and gates on its own in-container `swift test`, so this is a visibility gap rather than a correctness one; setting the secret to a PAT needs a person, not a commit.